### PR TITLE
update snmp-notifier-push.yaml file for Rhel10 testing push workflow

### DIFF
--- a/.tekton/snmp-notifier-push.yaml
+++ b/.tekton/snmp-notifier-push.yaml
@@ -291,7 +291,9 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: BINARY_IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
@@ -614,7 +616,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-snmp-notifier
+    serviceAccountName: build-pipeline-snmp-notifier-9-0
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
Hello Team,

When code changes were merged or pushed to base branch ( in this case `release-9.0`), the Konflux build was failing due to incorrect configuration in the on-push workflow file. This PR ensures that the CI pipeline triggers and runs successfully on push events.

Konflux push build failure : https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/ceph-tenant/applications/ceph-9-0/pipelineruns/snmp-notifier-9-0-on-push-gcq5l/