### PR TITLE
Testing Konflux builds for RHEL10 image on push events

### DIFF
--- a/.tekton/snmp-notifier-push.yaml
+++ b/.tekton/snmp-notifier-push.yaml
@@ -291,9 +291,7 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: BINARY_IMAGE_DIGEST
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        value: $(params.output-image)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT


### PR DESCRIPTION
Testing Konflux build failures on push event.

Failed build : https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/ceph-tenant/applications/ceph-9-0/pipelineruns/snmp-notifier-9-0-on-push-l5xvw/logs?task=rpms-signature-scan