### PR TITLE
setup snmp-notifier 6.1 container in konflux

### DIFF
--- a/.tekton/snmp-notifier-6-1-pull-request.yaml
+++ b/.tekton/snmp-notifier-6-1-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/rhceph-dev/snmp-notifier:on-pr-v6.1-{{revision}}
+    value: quay.io/rhceph-ci/snmp-notifier:on-pr-v6.1-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/snmp-notifier-6-1-push.yaml
+++ b/.tekton/snmp-notifier-6-1-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/rhceph-dev/snmp-notifier:v6.1-{{revision}}
+    value: quay.io/rhceph-ci/snmp-notifier:v6.1-{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage 1
 
 #FROM openshift/golang-builder:rhel_9_golang_1.23 AS builder
-FROM quay.io/projectquay/golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:1.24 AS builder
 
 COPY snmp_notifier snmp_notifier
 
@@ -22,7 +22,7 @@ RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -mod=readonly \
     -a -tags netgo
 
 # Build stage 2
-FROM registry.redhat.io/ubi9/ubi-minimal
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9-minimal:latest
 
 # Update the image to get the latest CVE updates
 RUN microdnf update -y && \
@@ -47,4 +47,3 @@ RUN chmod +x "$OPBIN"
 EXPOSE 9464
 ENTRYPOINT ["/usr/local/bin/snmp_notifier"]
 CMD ["--snmp.trap-description-template=/etc/snmp_notifier/description-template.tpl"]
-


### PR DESCRIPTION
Hello @andrewschoen ,

This PR contains following changes for snmp-notifier 6.1 release branch.

1. Change rhceph-dev to rhceph-ci
2. Pass the argument `--platform=$BUILDPLATFORM`  in Dockerfile for multi-platform builds

Please help me review and merging of this PR, thanks !