### PR TITLE
9.0: change rhceph-dev to rhceph-ci and add additional tags

### DIFF
--- a/.tekton/snmp-notifier-pull-request.yaml
+++ b/.tekton/snmp-notifier-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/rhceph-dev/snmp-notifier:on-pr-{{revision}}
+    value: quay.io/rhceph-ci/snmp-notifier:on-pr-v9.0-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -557,6 +557,11 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+          - "pull-request-{{pull_request_number}}"
+          - "from-branch-{{source_branch}}"
+          - "{{target_branch}}-$(tasks.clone-repository.results.commit-timestamp)"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/snmp-notifier-push.yaml
+++ b/.tekton/snmp-notifier-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/rhceph-dev/snmp-notifier:{{revision}}
+    value: quay.io/rhceph-ci/snmp-notifier:v9.0-{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -552,6 +552,10 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+          - "v9.0"
+          - "{{target_branch}}-$(tasks.clone-repository.results.commit-timestamp)"
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
Hello @andrewschoen ,

This PR contains following changes for snmp-notifier 9.0 release branch.

1. Change rhceph-dev to rhceph-ci
2. Add additional tags

Please help me review and merging of this PR, thanks !